### PR TITLE
Make vision sensor images compatible with pytorch

### DIFF
--- a/pyrep/backend/vrep.py
+++ b/pyrep/backend/vrep.py
@@ -191,10 +191,10 @@ def simGetVisionSensorImage(sensorHandle, resolution):
     T = ffi.getctype(ffi.typeof(img_buffer).item)  # Buffer data type
     s = ffi.sizeof(T)  # datatype size
     np_T = np.dtype('f{:d}'.format(s))  # Numpy equivalent, e.g. float is 'f4'
-    # Wrap the buffer with numpy. Take a copy otherwise the data is lost when we release the buffer
-    img = np.frombuffer(ffi.buffer(img_buffer, resolution[0]*resolution[1]*3*s ), np_T).copy()
+    # Wrap the buffer with numpy.
+    img = np.frombuffer(ffi.buffer(img_buffer, resolution[0]*resolution[1]*3*s), np_T)
     img = img.reshape(resolution[1], resolution[0], 3)
-    img = np.flip(img, 0)  # Image is upside-down
+    img = np.flip(img, 0).copy()  # Image is upside-down
     simReleaseBuffer(ffi.cast('char *', img_buffer))
     return img
 
@@ -204,10 +204,10 @@ def simGetVisionSensorDepthBuffer(sensorHandle, resolution):
     T = ffi.getctype(ffi.typeof(img_buffer).item)  # Buffer data type
     s = ffi.sizeof(T)  # datatype size
     np_T = np.dtype('f{:d}'.format(s))  # Numpy equivalent, e.g. float is 'f4'
-    # Wrap the buffer with numpy. Take a copy otherwise the data is lost when we release the buffer
-    img = np.frombuffer(ffi.buffer(img_buffer, resolution[0]*resolution[1]*s ), np_T).copy()
+    # Wrap the buffer with numpy.
+    img = np.frombuffer(ffi.buffer(img_buffer, resolution[0]*resolution[1]*s), np_T)
     img = img.reshape(resolution[1], resolution[0])
-    img = np.flip(img, 0)  # Image is upside-down
+    img = np.flip(img, 0).copy()  # Image is upside-down
     simReleaseBuffer(ffi.cast('char *', img_buffer))
     return img
 


### PR DESCRIPTION
Move the location of the `.copy()` in `simGetVisionSensorImage` and `simGetVisionSensorDepthBuffer` to after the `.flip()` in order to avoid the following error message:

```
torch.from_numpy(image)
>>> ValueError: some of the strides of a given numpy array are negative. This is currently not supported, but will be added in future releases.
```