### PR TITLE
Use defined object class in get_objects_in_tree

### DIFF
--- a/pyrep/objects/cartesian_path.py
+++ b/pyrep/objects/cartesian_path.py
@@ -1,6 +1,6 @@
 from typing import Tuple, List
 from pyrep.backend import sim
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType
 
 
@@ -90,3 +90,6 @@ class CartesianPath(Object):
         return sim.simExtCallScriptFunction(
             func, sim.sim_scripttype_addonscript,
             list(ints), list(floats), list(strings), bytes)
+
+
+object_type_to_class[ObjectType.PATH] = CartesianPath

--- a/pyrep/objects/dummy.py
+++ b/pyrep/objects/dummy.py
@@ -1,4 +1,4 @@
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType
 from pyrep.backend import sim
 
@@ -21,3 +21,6 @@ class Dummy(Object):
 
     def _get_requested_type(self) -> ObjectType:
         return ObjectType.DUMMY
+
+
+object_type_to_class[ObjectType.DUMMY] = Dummy

--- a/pyrep/objects/force_sensor.py
+++ b/pyrep/objects/force_sensor.py
@@ -1,6 +1,6 @@
 from typing import Tuple, List
 from pyrep.backend import sim
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType
 
 
@@ -20,3 +20,6 @@ class ForceSensor(Object):
         """
         _, forces, torques = sim.simReadForceSensor(self._handle)
         return forces, torques
+
+
+object_type_to_class[ObjectType.FORCE_SENSOR] = ForceSensor

--- a/pyrep/objects/joint.py
+++ b/pyrep/objects/joint.py
@@ -1,7 +1,7 @@
 from typing import Tuple, List, Union
 from pyrep.backend import sim
 from pyrep.const import JointType, JointMode
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType
 
 
@@ -246,3 +246,6 @@ class Joint(Object):
         :param value: The new joint mode value.
         """
         sim.simSetJointMode(self._handle, value.value)
+
+
+object_type_to_class[ObjectType.JOINT] = Joint

--- a/pyrep/objects/object.py
+++ b/pyrep/objects/object.py
@@ -6,6 +6,9 @@ from typing import List, Tuple, Union
 import numpy as np
 
 
+object_type_to_class = {}
+
+
 class Object(object):
     """Base class for V-REP scene objects that are used for building a scene.
 
@@ -598,7 +601,9 @@ class Object(object):
             self._handle, object_type.value, options)
         objects = []
         for h in handles:
-            objects.append(Object(h))
+            object_type = ObjectType(sim.simGetObjectType(h))
+            cls = object_type_to_class.get(object_type, Object)
+            objects.append(cls(h))
         return objects
 
     def copy(self) -> 'Object':

--- a/pyrep/objects/proximity_sensor.py
+++ b/pyrep/objects/proximity_sensor.py
@@ -1,7 +1,7 @@
 from math import sqrt
 
 from pyrep.backend import sim
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType
 
 
@@ -36,3 +36,6 @@ class ProximitySensor(Object):
         state, point = sim.simCheckProximitySensor(
             self._handle, obj.get_handle())
         return state == 1
+
+
+object_type_to_class[ObjectType.PROXIMITY_SENSOR] = ProximitySensor

--- a/pyrep/objects/shape.py
+++ b/pyrep/objects/shape.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 from pyrep.backend import sim
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 from pyrep.const import ObjectType, PrimitiveShape, TextureMappingMode
 from pyrep.textures.texture import Texture
 import os
@@ -356,3 +356,6 @@ class Shape(Object):
         """
         handles = sim.simUngroupShape(self.get_handle())
         return [Shape(handle) for handle in handles]
+
+
+object_type_to_class[ObjectType.SHAPE] = Shape

--- a/pyrep/objects/vision_sensor.py
+++ b/pyrep/objects/vision_sensor.py
@@ -1,7 +1,7 @@
 import math
 from typing import List, Union
 from pyrep.backend import sim
-from pyrep.objects.object import Object
+from pyrep.objects.object import Object, object_type_to_class
 import numpy as np
 from pyrep.const import ObjectType, PerspectiveMode, RenderMode
 
@@ -265,3 +265,6 @@ class VisionSensor(Object):
         sim.simSetObjectFloatParameter(
             self._handle, sim.sim_visionfloatparam_far_clipping, far_clipping
         )
+
+
+object_type_to_class[ObjectType.VISION_SENSOR] = VisionSensor

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -142,8 +142,12 @@ class TestObjects(TestCore):
 
     def test_get_objects_in_tree(self):
         dummys = [Dummy('nested_dummy%d' % i) for i in range(3)]
-        self.assertListEqual(dummys[0].get_objects_in_tree(
-            exclude_base=False, first_generation_only=False), dummys)
+
+        objects = dummys[0].get_objects_in_tree(
+            exclude_base=False, first_generation_only=False)
+        self.assertListEqual(objects, dummys)
+        for obj in objects:
+            self.assertIs(type(obj), Dummy)
 
         self.assertListEqual(
             dummys[0].get_objects_in_tree(


### PR DESCRIPTION
## Before
```
$ python example.py
Panda_joint1: <pyrep.objects.object.Object object at 0x7f803c1e36d0>
Panda_link0_visual: <pyrep.objects.object.Object object at 0x7f803c1e3790>
Panda_target: <pyrep.objects.object.Object object at 0x7f803c23cb50>
Panda_link1_respondable: <pyrep.objects.object.Object object at 0x7f803c23ca90>
Panda_joint2: <pyrep.objects.object.Object object at 0x7f803c23cad0>
Panda_link1_visual: <pyrep.objects.object.Object object at 0x7f803c23cb90>
Panda_link2_respondable: <pyrep.objects.object.Object object at 0x7f803c23cbd0>
Panda_joint3: <pyrep.objects.object.Object object at 0x7f803c23cc10>
Panda_link2_visual: <pyrep.objects.object.Object object at 0x7f803c23ced0>
Panda_link3_respondable: <pyrep.objects.object.Object object at 0x7f803c23cb10>
Panda_joint4: <pyrep.objects.object.Object object at 0x7f803c23cf10>
Panda_link3_visual: <pyrep.objects.object.Object object at 0x7f803c23cf50>
Panda_link4_respondable: <pyrep.objects.object.Object object at 0x7f803c23cf90>
Panda_joint5: <pyrep.objects.object.Object object at 0x7f803c23cfd0>
Panda_link4_visual: <pyrep.objects.object.Object object at 0x7f803c244050>
Panda_link5_respondable: <pyrep.objects.object.Object object at 0x7f803c244090>
Panda_joint6: <pyrep.objects.object.Object object at 0x7f803c2440d0>
Panda_link5_visual: <pyrep.objects.object.Object object at 0x7f803c244110>
Panda_link6_respondable: <pyrep.objects.object.Object object at 0x7f803c244150>
Panda_joint7: <pyrep.objects.object.Object object at 0x7f803c244190>
Panda_link6_visual: <pyrep.objects.object.Object object at 0x7f803c2441d0>
Panda_link7_respondable: <pyrep.objects.object.Object object at 0x7f803c244210>
Panda_attachment: <pyrep.objects.object.Object object at 0x7f803c244250>
Panda_link7_visual: <pyrep.objects.object.Object object at 0x7f803c244290>
Panda_gripper: <pyrep.objects.object.Object object at 0x7f803c2442d0>
Panda_gripper_joint1: <pyrep.objects.object.Object object at 0x7f803c244310>
Panda_gripper_joint2: <pyrep.objects.object.Object object at 0x7f803c244350>
Panda_gripper_visual: <pyrep.objects.object.Object object at 0x7f803c244390>
Panda_gripper_attach_point: <pyrep.objects.object.Object object at 0x7f803c2443d0>
Panda_tip: <pyrep.objects.object.Object object at 0x7f803c244410>
Panda_gripper_grasp_sensor: <pyrep.objects.object.Object object at 0x7f803c244450>
Panda_leftfinger_respondable: <pyrep.objects.object.Object object at 0x7f803c244490>
Panda_rightfinger_respondable: <pyrep.objects.object.Object object at 0x7f803c2444d0>
Panda_leftfinger_visible: <pyrep.objects.object.Object object at 0x7f803c244510>
Panda_rightfinger_visual: <pyrep.objects.object.Object object at 0x7f803c244550>
```

## After

```
$ python example.py
Panda_joint1: <pyrep.objects.joint.Joint object at 0x7f3bde54d610>
Panda_link0_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4de950>
Panda_target: <pyrep.objects.dummy.Dummy object at 0x7f3bde4de850>
Panda_link1_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4de890>
Panda_joint2: <pyrep.objects.joint.Joint object at 0x7f3bde4de8d0>
Panda_link1_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4de990>
Panda_link2_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4de9d0>
Panda_joint3: <pyrep.objects.joint.Joint object at 0x7f3bde4dea10>
Panda_link2_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4decd0>
Panda_link3_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4de910>
Panda_joint4: <pyrep.objects.joint.Joint object at 0x7f3bde4ded10>
Panda_link3_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4ded50>
Panda_link4_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4ded90>
Panda_joint5: <pyrep.objects.joint.Joint object at 0x7f3bde4dedd0>
Panda_link4_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4dee10>
Panda_link5_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4dee50>
Panda_joint6: <pyrep.objects.joint.Joint object at 0x7f3bde4dee90>
Panda_link5_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4deed0>
Panda_link6_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4def10>
Panda_joint7: <pyrep.objects.joint.Joint object at 0x7f3bde4def50>
Panda_link6_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4def90>
Panda_link7_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4defd0>
Panda_attachment: <pyrep.objects.force_sensor.ForceSensor object at 0x7f3bde4e7050>
Panda_link7_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4e7090>
Panda_gripper: <pyrep.objects.shape.Shape object at 0x7f3bde4e70d0>
Panda_gripper_joint1: <pyrep.objects.joint.Joint object at 0x7f3bde4e7110>
Panda_gripper_joint2: <pyrep.objects.joint.Joint object at 0x7f3bde4e7150>
Panda_gripper_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4e7190>
Panda_gripper_attach_point: <pyrep.objects.force_sensor.ForceSensor object at 0x7f3bde4e71d0>
Panda_tip: <pyrep.objects.dummy.Dummy object at 0x7f3bde4e7210>
Panda_gripper_grasp_sensor: <pyrep.objects.proximity_sensor.ProximitySensor object at 0x7f3bde4e7250>
Panda_leftfinger_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4e7290>
Panda_rightfinger_respondable: <pyrep.objects.shape.Shape object at 0x7f3bde4e72d0>
Panda_leftfinger_visible: <pyrep.objects.shape.Shape object at 0x7f3bde4e7310>
Panda_rightfinger_visual: <pyrep.objects.shape.Shape object at 0x7f3bde4e7350>
```

`example.py`

```
from os.path import dirname, join, abspath
from pyrep import PyRep
from pyrep.robots.arms.panda import Panda

SCENE_FILE = join(dirname(abspath(__file__)), 'scene_panda_reach_target.ttt')
DELTA = 0.01
pr = PyRep()
pr.launch(SCENE_FILE, headless=False)
pr.start()
agent = Panda()

for obj in agent.get_objects_in_tree():
    print(f'{obj.get_name()}: {obj}')

pr.stop()
pr.shutdown()
```