### PR TITLE
Fix docs with correct autodoc_mock_imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,7 @@ extensions = [
     'sphinx.ext.napoleon'
 ]
 
-autodoc_mock_imports = ["pyrep.backend._v_rep_cffi"]
+autodoc_mock_imports = ["pyrep.backend._sim_cffi"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
It is broken now https://pyrep.readthedocs.io/en/latest/pyrep.objects.html#pyrep-objects-object-module