### PR TITLE
Better solution for suppressing stdout from shared lib

### DIFF
--- a/pyrep/__init__.py
+++ b/pyrep/__init__.py
@@ -1,1 +1,3 @@
+testing = False
+
 from .pyrep import PyRep

--- a/pyrep/backend/utils.py
+++ b/pyrep/backend/utils.py
@@ -3,6 +3,7 @@ import io
 import sys
 from contextlib import contextmanager
 from typing import List, Tuple
+from pyrep import testing
 from pyrep.backend import sim
 from pyrep.objects.object import Object
 from pyrep.objects.shape import Shape
@@ -84,12 +85,20 @@ def suppress_std_out_and_err():
         def _redirect_stdout(to_fd):
             sys.stdout.close()
             os.dup2(to_fd, original_stdout_fd)
-            sys.stdout = io.TextIOWrapper(os.fdopen(original_stdout_fd, 'wb'))
+            if testing:
+                sys.stdout = io.TextIOWrapper(
+                    os.fdopen(original_stdout_fd, 'wb'))
+            else:
+                sys.stdout = os.fdopen(original_stdout_fd, 'w')
 
         def _redirect_stderr(to_fd):
             sys.stderr.close()
             os.dup2(to_fd, original_stderr_fd)
-            sys.stderr = io.TextIOWrapper(os.fdopen(original_stderr_fd, 'wb'))
+            if testing:
+                sys.stderr = io.TextIOWrapper(
+                    os.fdopen(original_stderr_fd, 'wb'))
+            else:
+                sys.stderr = os.fdopen(original_stderr_fd, 'wb')
 
         saved_stdout_fd = os.dup(original_stdout_fd)
         # saved_stderr_fd = os.dup(original_stderr_fd)

--- a/tests/core.py
+++ b/tests/core.py
@@ -1,8 +1,10 @@
 import unittest
+import pyrep
 from pyrep import PyRep
 from os import path
 
 ASSET_DIR = path.join(path.dirname(path.abspath(__file__)), 'assets')
+pyrep.testing = True
 
 
 class TestCore(unittest.TestCase):


### PR DESCRIPTION
Check below code on Terminal with/without this change.
~~Please tell me if you want to keep previous function name.~~

```python
import time

import pyrep

pr = pyrep.PyRep()

with pyrep.backend.utils.suppress_std_out_and_err():
    pr.launch(headless=True)

for i in range(5):
    print(i)
    time.sleep(1)

pr.shutdown()
```