### PR TITLE
Assert object type even when handle is given

### DIFF
--- a/pyrep/objects/object.py
+++ b/pyrep/objects/object.py
@@ -20,12 +20,12 @@ class Object(object):
             self._handle = name_or_handle
         else:
             self._handle = sim.simGetObjectHandle(name_or_handle)
-            assert_type = self._get_requested_type()
-            actual = ObjectType(sim.simGetObjectType(self._handle))
-            if actual != assert_type:
-                raise WrongObjectTypeError(
-                    'You requested object of type %s, but the actual type was '
-                    '%s' % (assert_type.name, actual.name))
+        assert_type = self._get_requested_type()
+        actual = ObjectType(sim.simGetObjectType(self._handle))
+        if actual != assert_type:
+            raise WrongObjectTypeError(
+                'You requested object of type %s, but the actual type was '
+                '%s' % (assert_type.name, actual.name))
 
     def __eq__(self, other: object):
         if not isinstance(other, Object):

--- a/pyrep/objects/object.py
+++ b/pyrep/objects/object.py
@@ -246,7 +246,9 @@ class Object(object):
         except RuntimeError:
             # Most probably no parent.
             return None
-        return Object(handle)
+        object_type = ObjectType(sim.simGetObjectType(handle))
+        cls = object_type_to_class.get(object_type, Object)
+        return cls(handle)
 
     def set_parent(self, parent_object: Union['Object', None],
                    keep_in_place=True) -> None:

--- a/pyrep/pyrep.py
+++ b/pyrep/pyrep.py
@@ -235,8 +235,11 @@ class PyRep(object):
         :return: A single merged shape.
         """
         handles = [o.get_handle() for o in objects]
-        handle = sim.simGroupShapes(handles, merge=True)
-        return Shape(handle)
+        # FIXME: sim.simGroupShapes(merge=True) won't return correct handle,
+        # so we use name to find correct handle of the merged shape.
+        name = objects[-1].get_name()
+        sim.simGroupShapes(handles, merge=True)
+        return Shape(name)
 
     def import_model(self, filename: str) -> Object:
         """	Loads a previously saved model.

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -32,7 +32,8 @@ class TestObjects(TestCore):
 
     def test_still_exists(self):
         self.assertTrue(self.dynamic_cube.still_exists())
-        self.assertFalse(Shape(-1).still_exists())
+        self.dynamic_cube.remove()
+        self.assertFalse(self.dynamic_cube.still_exists())
 
     def test_object_exists(self):
         yes = Object.exists('dynamic_cube')


### PR DESCRIPTION
This missing assertion can hide errors since it won't raise anything when handle (integer) is given to the Object-related class.