### PR TITLE
Add pyrep.suppress_std_out_err

### DIFF
--- a/pyrep/__init__.py
+++ b/pyrep/__init__.py
@@ -1,3 +1,4 @@
 testing = False
+suppress_std_out_err = True
 
 from .pyrep import PyRep

--- a/pyrep/backend/utils.py
+++ b/pyrep/backend/utils.py
@@ -79,6 +79,10 @@ def suppress_std_out_and_err():
     This is needed because the OMPL plugin outputs logging info even when
     logging is turned off.
     """
+    if not pyrep.suppress_std_out_err:
+        yield
+        return
+
     try:
         # If we are using an IDE, then this will fail
         original_stdout_fd = sys.stdout.fileno()


### PR DESCRIPTION
I found that this `with pyrep.backend.utils.suppress_std_out_err` won't work with other libraries that access to the terminal stdout (e.g., progress bar by tqdm, pyprind).
So I need to turn off this suppression when I use them. (I use an RL framework, which uses progress bar inside).

This is a bit inconvenient because when I do training RL agent on PyRep, the terminal is full of logs from Coppeliasim.

I asked question in the Coppeliasim Forum: https://forum.coppeliarobotics.com/viewtopic.php?f=9&t=8328.