### PR TITLE
PyRep launch option to write CoppeliaSim stdout to file instead of terminal.

### DIFF
--- a/pyrep/pyrep.py
+++ b/pyrep/pyrep.py
@@ -1,4 +1,5 @@
 import numpy as np
+from contextlib import contextmanager
 from pyrep.backend import sim, utils
 from pyrep.objects.object import Object
 from pyrep.objects.shape import Shape
@@ -11,6 +12,32 @@ import threading
 from threading import Lock
 from typing import Tuple, List
 import warnings
+
+
+def fileno(file_or_fd):
+    fd = getattr(file_or_fd, 'fileno', lambda: file_or_fd)()
+    if not isinstance(fd, int):
+        raise ValueError("Expected a file (`.fileno()`) or a file descriptor")
+    return fd
+
+
+@contextmanager
+def stdout_redirected(to=os.devnull, stdout=None):
+    if stdout is None:
+        stdout = sys.stdout
+    stdout_fd = fileno(stdout)
+    with os.fdopen(os.dup(stdout_fd), 'wb') as copied:
+        stdout.flush()
+        try:
+            os.dup2(fileno(to), stdout_fd)
+        except ValueError:
+            with open(to, 'wb') as to_file:
+                os.dup2(to_file.fileno(), stdout_fd)
+        try:
+            yield stdout
+        finally:
+            stdout.flush()
+            os.dup2(copied.fileno(), stdout_fd)
 
 
 class PyRep(object):
@@ -44,12 +71,16 @@ class PyRep(object):
                 'COPPELIASIM_ROOT was not a correct path. '
                 'See installation instructions')
 
-    def _run_ui_thread(self, scene_file: str, headless: bool) -> None:
+    def _run_ui_thread(self, scene_file: str, headless: bool, write_coppeliasim_stdout_to_file: bool) -> None:
         # Need this otherwise extensions will not be loaded
         os.chdir(self._vrep_root)
         options = sim.sim_gui_headless if headless else sim.sim_gui_all
-        sim.simExtLaunchUIThread(options=options, scene=scene_file,
-                                 pyrep_root=self._vrep_root)
+        if write_coppeliasim_stdout_to_file:
+            with open('/tmp/CoppeliaSimLog' + str(time.perf_counter()).replace('.', '') + '.txt', 'w+') as f, \
+                    stdout_redirected(f):
+                sim.simExtLaunchUIThread(options=options, scene=scene_file, pyrep_root=self._vrep_root)
+        else:
+            sim.simExtLaunchUIThread(options=options, scene=scene_file, pyrep_root=self._vrep_root)
 
     def _run_responsive_ui_thread(self) -> None:
         while True:
@@ -65,7 +96,7 @@ class PyRep(object):
             self.shutdown()
 
     def launch(self, scene_file="", headless=False, responsive_ui=False,
-               blocking=False) -> None:
+               blocking=False, write_coppeliasim_stdout_to_file=False) -> None:
         """Launches CoppeliaSim.
 
         Launches the UI thread, waits until the UI thread has finished, this
@@ -79,13 +110,16 @@ class PyRep(object):
         :param blocking: Causes CoppeliaSim to launch as if running the default
             c++ client application. This is causes the function to block.
             For most users, this will be set to False.
+        :param write_coppeliasim_stdout_to_file: Causes CoppeliaSim to write the stdout to files in /tmp, rather than
+            the terminal stdout as the python script is run. This helps reduce screen clutter, particularly if using
+            multiple PyRep instances with multiprocessing, for example.
         """
         abs_scene_file = os.path.abspath(scene_file)
         if len(scene_file) > 0 and not os.path.isfile(abs_scene_file):
             raise PyRepError('Scene file does not exist: %s' % scene_file)
         cwd = os.getcwd()
         self._ui_thread = threading.Thread(target=self._run_ui_thread,
-                                           args=(abs_scene_file, headless))
+                                           args=(abs_scene_file, headless, write_coppeliasim_stdout_to_file))
         self._ui_thread.daemon = True
         self._ui_thread.start()
 


### PR DESCRIPTION
This could help reduce terminal clutter, if other important messages are required in the terminal from the wider python program. This is also particularly useful for multiprocessing, if there are many PyRep instances running in parallelm, all producing stdout output. Further, having PyRep instance-specific log files could help debugging if CoppeliaSim crashes occur.