### PR TITLE
Fix octree init

### DIFF
--- a/pyrep/backend/utils.py
+++ b/pyrep/backend/utils.py
@@ -14,6 +14,7 @@ from pyrep.objects.vision_sensor import VisionSensor
 from pyrep.objects.force_sensor import ForceSensor
 from pyrep.objects.proximity_sensor import ProximitySensor
 from pyrep.objects.camera import Camera
+from pyrep.objects.octree import Octree
 
 
 def to_type(handle: int) -> Object:
@@ -39,6 +40,8 @@ def to_type(handle: int) -> Object:
         return ProximitySensor(handle)
     elif t == sim.sim_object_camera_type:
         return Camera(handle)
+    elif t == sim.sim_object_octree_type:
+        return Octree(handle)
     raise ValueError
 
 

--- a/pyrep/objects/octree.py
+++ b/pyrep/objects/octree.py
@@ -1,10 +1,13 @@
-from pyrep.objects.object import Object
-from pyrep.const import ObjectType
 from pyrep.backend import sim
-from typing import List, Optional
+from typing import List, Optional, Union
+from pyrep.objects.object import Object, object_type_to_class
+from pyrep.const import ObjectType
 
 class Octree(Object):
     """An octree object."""
+
+    def __init__(self, name_or_handle: Union[str, int]):
+        super().__init__(name_or_handle)
 
     @staticmethod
     def create(voxel_size: float, point_size: Optional[float] = None,
@@ -116,3 +119,5 @@ class Octree(Object):
         """Clears all voxels from the octree.
         """
         sim.simRemoveVoxelsFromOctree(self._handle, 0, None)
+
+object_type_to_class[ObjectType.OCTREE] = Octree


### PR DESCRIPTION
Fixing octree init and utils.to_type import, that keeps the "no octree support" warning from appearing, and full implement it on the pyrep