### PR TITLE
Update joint.py

### DIFF
--- a/pyrep/objects/joint.py
+++ b/pyrep/objects/joint.py
@@ -133,7 +133,7 @@ class Joint(Object):
         :param force: The maximum force or torque that the joint can exert.
             This cannot be a negative value.
         """
-        sim.simSetJointForce(self._handle, force)
+        sim.simSetJointMaxForce(self._handle, force)
 
     def get_joint_velocity(self) -> float:
         """Get the current joint velocity.


### PR DESCRIPTION
With the latest version of CoppeliaSim 4.1.0 (rev1), I noticed that it's only possible to set the maximum torque on a joint by using `sim.simSetJointMaxForce`. Please review it.