### PR TITLE
Fix set joint position

### DIFF
--- a/pyrep/objects/joint.py
+++ b/pyrep/objects/joint.py
@@ -44,7 +44,7 @@ class Joint(Object):
             when the joint mode is in Force mode. It will disable dynamics,
             move the joint, and then re-enable dynamics.
 
-        :param positions: A list of positions of the joints (angular or linear
+        :param position: Position of a joint (angular or linear
             values depending on the joint type).
         """
         if not disable_dynamics:

--- a/pyrep/objects/joint.py
+++ b/pyrep/objects/joint.py
@@ -65,11 +65,11 @@ class Joint(Object):
         sim.simSetJointPosition(self._handle, position)
         self.set_joint_target_position(position)
 
+        with utils.step_lock:
+            sim.simExtStep(True)  # Have to step for changes to take effect
         # Re-enable the dynamics
         sim.simSetModelProperty(self._handle, prior)
         self.set_model(is_model)
-        with utils.step_lock:
-            sim.simExtStep(True)  # Have to step for changes to take effect
 
     def get_joint_target_position(self) -> float:
         """Retrieves the target position of a joint.

--- a/pyrep/robots/configuration_paths/arm_configuration_path.py
+++ b/pyrep/robots/configuration_paths/arm_configuration_path.py
@@ -59,11 +59,11 @@ class ArmConfigurationPath(ConfigurationPath):
         self._arm.set_joint_positions(start_config)
         self._path_done = False
 
-    def set_to_end(self) -> None:
+    def set_to_end(self, disable_dynamics=False) -> None:
         """Sets the arm to the end of this path.
         """
         final_config = self._path_points[-len(self._arm.joints):]
-        self._arm.set_joint_positions(final_config)
+        self._arm.set_joint_positions(final_config, disable_dynamics=disable_dynamics)
 
     def visualize(self) -> None:
         """Draws a visualization of the path in the scene.

--- a/pyrep/robots/configuration_paths/arm_configuration_path.py
+++ b/pyrep/robots/configuration_paths/arm_configuration_path.py
@@ -52,11 +52,11 @@ class ArmConfigurationPath(ConfigurationPath):
         self._path_done = done
         return done
 
-    def set_to_start(self) -> None:
+    def set_to_start(self, disable_dynamics=False) -> None:
         """Sets the arm to the beginning of this path.
         """
         start_config = self._path_points[:len(self._arm.joints)]
-        self._arm.set_joint_positions(start_config)
+        self._arm.set_joint_positions(start_config, disable_dynamics=disable_dynamics)
         self._path_done = False
 
     def set_to_end(self, disable_dynamics=False) -> None:

--- a/pyrep/robots/robot_component.py
+++ b/pyrep/robots/robot_component.py
@@ -109,12 +109,11 @@ class RobotComponent(Object):
          for jh, p in zip(self._joint_handles, positions)]
         [j.set_joint_target_position(p)  # type: ignore
          for j, p in zip(self.joints, positions)]
-
+        with utils.step_lock:
+            sim.simExtStep(True)  # Have to step for changes to take effect
         # Re-enable the dynamics
         sim.simSetModelProperty(self._handle, prior)
         self.set_model(is_model)
-        with utils.step_lock:
-            sim.simExtStep(True)  # Have to step for changes to take effect
 
     def get_joint_target_positions(self) -> List[float]:
         """Retrieves the target positions of the joints.


### PR DESCRIPTION
1. when set joint positions, first step the environment, then enable dynamics. This will fix the robot model that has both dynamic links and static links.
2. minor doc string fix for set_joint_position
3. add a `disable_dynamics` option in `set_to_end` function