### PR TITLE
Adds scale-related helper functions for objects

### DIFF
--- a/pyrep/backend/sim.py
+++ b/pyrep/backend/sim.py
@@ -745,6 +745,15 @@ def simSetShapeColor(shapeHandle, colorName, colorComponent, rgbData):
     _check_return(res)
 
 
+def simScaleObject(shapeHandle, scale_x, scale_y, scale_z):
+    ret = lib.simScaleObject(shapeHandle, scale_x, scale_y, scale_z, 0)
+    _check_return(ret)
+
+
+def simGetObjectSizeFactor(shapeHandle):
+    return lib.simGetObjectSizeFactor(shapeHandle)
+
+
 def simReorientShapeBoundingBox(shapeHandle, relativeToHandle):
     ret = lib.simReorientShapeBoundingBox(shapeHandle, relativeToHandle, 0)
     _check_return(ret)

--- a/pyrep/objects/object.py
+++ b/pyrep/objects/object.py
@@ -120,6 +120,27 @@ class Object(object):
         """
         sim.simSetObjectName(self._handle, name)
 
+    def scale_object(self, scale_x: float, scale_y: float, scale_z: float) -> None:
+        """Scales the object by the given amounts in the x, y, z axes
+
+        Note that this function apply the given scale to the object, it doesn't
+        set the scale factors. This means that if you apply two calls to this
+        function with factors of 2.0, this results in the object being scaled
+        by a factor of 4 in total (it doesn't set an internal scale factor!)
+
+        :param scale_x: The scaling factor along the object's x axis
+        :param scale_y: The scaling factor along the object's y axis
+        :param scale_z: The scaling factor along the object's z axis
+        """
+        sim.simScaleObject(self._handle, scale_x, scale_y, scale_z)
+
+    def get_size_factor(self) -> float:
+        """Gets the object size factor (for scaling purposes)
+
+        :return: The object's size factor
+        """
+        return sim.simGetObjectSizeFactor(self._handle)
+
     def get_position(self, relative_to=None) -> np.ndarray:
         """Gets the position of this object.
 


### PR DESCRIPTION
This PR adds some functionality to the `Object` API such that we can control the scale of objects at runtime. Please note the following:

- The exposed `Object::scale_object` method can be used to update the scale of an object in any of the three axes.
- The scale is applied in sequence as the user calls it. By this I mean that if you apply `scaleObject` twice with a factor of 2, then you'll get a resulting total scale factor of 4 (doesn't set an internal scale to 2 twice, but compounds the effects).
- The exposed `Object::get_size_factor` method doesn't get the actual scale factors in the three axes, but instead returns a single scale factor that it's related to the scale (if the `scale_object` method was used with all three scale factors set equal).
- Even though these two functions seem to control different properties of an object (it seems that the `get_size_factor` returns the cubic root of the product of the three scale factors), these functions can be used to build a separate `set_scale` function that does **set** the scale as expected.

There's a test notebook in a separate branch [here](https://github.com/wpumacay/PyRep/blob/test-obj-scale/tests/test_scale_objects.ipynb) to play around with these functions