### PR TITLE
Adds helper function to create convex hull shape

### DIFF
--- a/pyrep/backend/sim.py
+++ b/pyrep/backend/sim.py
@@ -959,6 +959,30 @@ def simImportMesh(fileformat, pathAndFilename, options,
     return retVerticies, retIndices, retNames
 
 
+def simGetConvexHullShape(pathAndFilename):
+    vertices, indices, _ = simImportMesh(0, pathAndFilename, 0, False, 1.0)
+
+    outVertices = ffi.new("float **")
+    outVerticesCount = ffi.new("int *")
+    outIndices = ffi.new("int **")
+    outIndicesCount = ffi.new("int *")
+    ret = lib.simGetQHull(vertices[0], len(vertices[0]),
+                          outVertices, outVerticesCount,
+                          outIndices, outIndicesCount, 0, ffi.NULL)
+    _check_return(ret)
+
+    mesh_options = 3
+    mesh_shading_angle = 20.0 * 3.1415 / 180.0
+    handle = lib.simCreateMeshShape(mesh_options, mesh_shading_angle,
+                                    outVertices[0], outVerticesCount[0],
+                                    outIndices[0], outIndicesCount[0],
+                                    ffi.NULL)
+
+    simReleaseBuffer(ffi.cast("char *", outVertices[0]))
+    simReleaseBuffer(ffi.cast("char *", outIndices[0]))
+    return handle
+
+
 def simImportShape(fileformat, pathAndFilename, options,
                    identicalVerticeTolerance, scalingFactor):
     handle = lib.simImportShape(


### PR DESCRIPTION
This PR adds an extra function to the `pyrep.backend.sim` module to create a shape out of the convex hull of a given model resource.

There's a test notebook in a separate branch [here](https://github.com/wpumacay/PyRep/blob/test-cvx-hull/examples/convex-hull-example/example_create_convex_hull.ipynb) and some assets to play around with this function.