### PR TITLE
Add `simScaleObjects` helper function

### DIFF
--- a/pyrep/backend/sim.py
+++ b/pyrep/backend/sim.py
@@ -750,6 +750,13 @@ def simScaleObject(shapeHandle, scale_x, scale_y, scale_z):
     _check_return(ret)
 
 
+def simScaleObjects(objectHandles, scale, scalePositionsToo=False):
+    handles = ffi.new("int[]", objectHandles)
+    ret = lib.simScaleObjects(handles, len(objectHandles), scale,
+                              scalePositionsToo)
+    _check_return(ret)
+
+
 def simGetObjectSizeFactor(shapeHandle):
     return lib.simGetObjectSizeFactor(shapeHandle)
 


### PR DESCRIPTION
This PR adds an extra function that wasn't exposed from the CoppeliaSim API. This function allows to scale objects correctly when dealing with the case of models and compound shapes. There is a test notebook in [this](https://github.com/wpumacay/PyRep/blob/test-scale-multiobjs/examples/test-scale-objs/test_notebook.ipynb) branch.