### PR TITLE
🐞 fix(Gripper): the use of join_intervals

### DIFF
--- a/pyrep/robots/end_effectors/gripper.py
+++ b/pyrep/robots/end_effectors/gripper.py
@@ -99,7 +99,7 @@ class Gripper(RobotComponent):
         joint_intervals = np.array(joint_intervals_list)
 
         # Decide on if we need to open or close
-        joint_range = joint_intervals[:, 1] - joint_intervals[:, 0]
+        joint_range = joint_intervals[:, 1]
         target_pos = joint_intervals[:, 0] + (joint_range * amount)
 
         current_positions = self.get_joint_positions()


### PR DESCRIPTION
## What this PR does
Fix issue #385 
Change the code of 102 of https://github.com/stepjam/PyRep/blob/master/pyrep/robots/end_effectors/gripper.py to `joint_rage = joint_intervals[:, 1]`.